### PR TITLE
Pass a StellarFederation::Query object on_query callback class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.2.0]
+### Added
+- Pass `StellarFederation::Query` to `.on_query` callback class
+
+## [0.1.0]
+### Added
+- Initial commit
+
+

--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ StellarFederation.configure do |c|
 end
 ```
 
-`c.on_query` - is a class the you define: The `on_query` class should also return a `StellarFederation::QueryResponse`. If it doesn't, the Rails engine will throw an exception. The `on_query` class will be called with `.call`, it should have a method that accepts a hash with the following parameters:
+`c.on_query` - is a class the you define: The `on_query` class should also return a `StellarFederation::QueryResponse`. If it doesn't, the Rails engine will throw an exception. The `on_query` class will be called with `.call`, that accepts a `StellarFederation::Query` object
   - `address_name` - ex: `tunder_adebayo*your_org.com`
+  - `address_id` - ex: `tunder_adebayo`
+  - `address_domain` - ex: `your_org.com`
 
 Add to your routes:
 

--- a/app/controllers/stellar_federation/api/v1/queries_controller.rb
+++ b/app/controllers/stellar_federation/api/v1/queries_controller.rb
@@ -3,30 +3,23 @@ module StellarFederation
     module V1
       class QueriesController < ApplicationController
         def index
-          check_parameters = Queries::CheckParameters.(query_params)
+          result = Queries::ProcessQuery.(query_params: query_params)
 
-          if check_parameters
-            @query_response = Queries::ProcessQuery.(query_params: query_params)
-              .query_response
+          respond_to do |format|
+            format.json do
+              if result.success?
+                @query_response = result.query_response
 
-            respond_to do |format|
-              format.json do
                 render json: @query_response.to_json, status: :ok
-              end
-            end
-          else
-            respond_to do |format|
-              format.json do
-                render(
-                  json: {
-                    status: "Unprocessable Entity",
-                    message: "Invalid Parameters",
-                  },
-                  status: :unprocessable_entity,
-                )
-              end
-            end
+              else
+                json_status = {
+                  status: "Unprocessable Entity",
+                  message: result.message,
+                }
 
+                render json: json_status, status: :unprocessable_entity
+              end
+            end
           end
 
         end

--- a/app/models/stellar_federation/query.rb
+++ b/app/models/stellar_federation/query.rb
@@ -1,0 +1,8 @@
+module StellarFederation
+  class Query < BaseModel
+
+    attribute :address_id, DryTypes::String.optional
+    attribute :address_domain, DryTypes::String.optional
+    attribute :address_name, DryTypes::String.optional
+  end
+end

--- a/app/services/stellar_federation/queries/check_parameters.rb
+++ b/app/services/stellar_federation/queries/check_parameters.rb
@@ -1,8 +1,13 @@
 module StellarFederation
   module Queries
     class CheckParameters
-      def self.call(params)
-        params[:q].present? && check_type(params[:type])
+      extend LightService::Action
+      expects :query_params
+
+      executed do |c|
+        unless c.query_params[:q].present? && check_type(c.query_params[:type])
+          c.fail! "Invalid Parameters"
+        end
       end
 
       private

--- a/app/services/stellar_federation/queries/parse_address_name.rb
+++ b/app/services/stellar_federation/queries/parse_address_name.rb
@@ -1,0 +1,19 @@
+module StellarFederation
+  module Queries
+    class ParseAddressName
+      extend LightService::Action
+      expects :query_params
+      promises :query
+
+      executed do |c|
+        address_name = c.query_params[:address_name]
+        split_address_name = address_name.split("*")
+        c.query = Query.new(
+          address_id: split_address_name[0],
+          address_domain: split_address_name[1],
+          address_name: address_name,
+        )
+      end
+    end
+  end
+end

--- a/app/services/stellar_federation/queries/process_query.rb
+++ b/app/services/stellar_federation/queries/process_query.rb
@@ -5,7 +5,9 @@ module StellarFederation
 
       def self.call(query_params:)
         with(query_params: query_params).reduce(
+          CheckParameters,
           PrepareOnQueryParameters,
+          ParseAddressName,
           TriggerOnQueryCallbackClass,
         )
       end

--- a/app/services/stellar_federation/queries/trigger_on_query_callback_class.rb
+++ b/app/services/stellar_federation/queries/trigger_on_query_callback_class.rb
@@ -2,12 +2,12 @@ module StellarFederation
   module Queries
     class TriggerOnQueryCallbackClass
       extend LightService::Action
-      expects :query_params
+      expects :query
       promises :query_response
 
       executed do |c|
         begin
-          c.query_response = callback_class.(c.query_params)
+          c.query_response = callback_class.(c.query)
 
           if !c.query_response.is_a? StellarFederation::QueryResponse
             raise_return_error

--- a/spec/dummy/app/services/process_stellar_federation_query.rb
+++ b/spec/dummy/app/services/process_stellar_federation_query.rb
@@ -1,7 +1,7 @@
 class ProcessStellarFederationQuery
 
-  def self.call(opts = {})
-    Rails.logger.info "Woot got a federation query #{opts}"
+  def self.call(query)
+    Rails.logger.info "Woot got a federation query #{query.to_hash}"
   end
 
 end

--- a/spec/dummy/app/services/processed_stellar_federation_query.rb
+++ b/spec/dummy/app/services/processed_stellar_federation_query.rb
@@ -1,8 +1,8 @@
 class ProcessedStellarFederationQuery
 
-  def self.call(opts = {})
+  def self.call(query)
     StellarFederation::QueryResponse.new(
-      stellar_address: opts[:address_name],
+      stellar_address: query.address_name,
       account_id: "FOOBAR",
       memo: 1,
     )

--- a/spec/models/stellar_federation/query_spec.rb
+++ b/spec/models/stellar_federation/query_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+module StellarFederation
+  RSpec.describe Query do
+    it "is a StellarFederation::Query" do
+      response = described_class.new({
+        address_id: "foo",
+        address_domain: "bar.com",
+        address_name: "foo*bar.com",
+      })
+
+      expect(response.address_id).to eq "foo"
+      expect(response.address_domain).to eq "bar.com"
+      expect(response.address_name).to eq "foo*bar.com"
+    end
+  end
+
+end

--- a/spec/services/stellar_federation/queries/check_parameters_spec.rb
+++ b/spec/services/stellar_federation/queries/check_parameters_spec.rb
@@ -4,28 +4,37 @@ module StellarFederation
   module Queries
     RSpec.describe CheckParameters do
       describe ".call" do
+        let(:ctx) { { query_params: query_params } }
+
         context "q is not present" do
+          let(:query_params) { { type: "name"} }
+
           it "returns false" do
-            expect(described_class.({ type: "name" })).to eq false
+            expect(described_class.execute(ctx).success?).to eq false
           end
         end
 
         context "type is not present" do
+          let(:query_params) { { q: "name"} }
+
           it "returns false" do
-            expect(described_class.({ q: "name" })).to eq false
+            expect(described_class.execute(ctx).success?).to eq false
           end
         end
 
         context "type is not 'name'" do
+          let(:query_params) { { type: "foo"} }
+
           it "returns false" do
-            expect(described_class.({ type: "foo" })).to eq false
+            expect(described_class.execute(ctx).success?).to eq false
           end
         end
 
         context "parameters are present" do
+          let(:query_params) { { q: "bar", type: "name" } }
+
           it "returns true" do
-            expect(
-              described_class.({ q: "bar", type: "name" })).to eq true
+            expect(described_class.execute(ctx).success?).to eq true
           end
         end
       end

--- a/spec/services/stellar_federation/queries/parse_address_name_spec.rb
+++ b/spec/services/stellar_federation/queries/parse_address_name_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+module StellarFederation
+  module Queries
+    RSpec.describe ParseAddressName do
+      it "splits the address_name into 2 parts: id and domain" do
+        query_params = { address_name: "foo*bar.com" }
+        result = described_class.execute(query_params: query_params)
+
+        expect(result.query.address_id).to eq "foo"
+        expect(result.query.address_domain).to eq "bar.com"
+        expect(result.query.address_name).to eq "foo*bar.com"
+      end
+    end
+  end
+end

--- a/spec/services/stellar_federation/queries/process_query_spec.rb
+++ b/spec/services/stellar_federation/queries/process_query_spec.rb
@@ -5,7 +5,9 @@ module StellarFederation
     RSpec.describe ProcessQuery do
       it "processes a query on the federation server" do
         actions = [
+          CheckParameters,
           PrepareOnQueryParameters,
+          ParseAddressName,
           TriggerOnQueryCallbackClass,
         ]
 

--- a/spec/services/stellar_federation/queries/trigger_on_query_callback_class_spec.rb
+++ b/spec/services/stellar_federation/queries/trigger_on_query_callback_class_spec.rb
@@ -3,24 +3,24 @@ require "spec_helper"
 module StellarFederation
   module Queries
     RSpec.describe TriggerOnQueryCallbackClass do
+      let(:query) { Query.new(address_id: "foo") }
 
       context "with configured callback class" do
         let(:query_response) { QueryResponse.new }
+
         it "triggers the configured callback class" do
           expect(ProcessStellarFederationQuery).to receive(:call)
-            .with(address_name: 'foo').and_return(query_response)
-          described_class.execute(query_params: { address_name: "foo" })
+            .with(query).and_return(query_response)
+          described_class.execute(query: query)
         end
       end
 
       context "with configured callback class and doesnt return QueryResponse" do
         it "triggers the configured callback class" do
           expect(ProcessStellarFederationQuery).to receive(:call)
-            .with(address_name: 'foo').and_return("test")
+            .with(query).and_return("test")
 
-          expect {
-            described_class.execute(query_params: { address_name: "foo" })
-          }.to raise_error(
+          expect { described_class.execute(query: query) }.to raise_error(
             StandardError,
             "ProcessStellarFederationQuery must return a StellarFederation::QueryResponse"
           )
@@ -28,14 +28,22 @@ module StellarFederation
       end
 
       context "without configured callback class" do
-        it "fails and returns an error" do
+        let(:query) { Query.new(address_id: "foo") }
+
+        before do
           StellarFederation.configure do |c|
             c.on_query = ""
           end
+        end
 
-          expect {
-            described_class.execute(query_params: { address_name: "foo" })
-          }.to raise_error(
+        after do
+          StellarFederation.configure do |c|
+            c.on_query = "ProcessStellarFederationQuery"
+          end
+        end
+
+        it "fails and returns an error" do
+          expect { described_class.execute(query: query) }.to raise_error(
             NameError,
             "StellarFederation.on_query isn't configured",
           )


### PR DESCRIPTION
This PR contains changes that will pass a parsed federation query to the on_query callback class via a data object named `StellarFederation::Query`.

This makes it more convenient to developers to make use of the federation queries for their own logic without creating additional parsers on their application. The rails engine should contain the responsibility of knowing how to receive and parse Stellar Federation queries.