### PR TITLE
Return 404 if records are not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.1]
+### Changed
+- Add returned status to `404` if record is not found
+- Allow `on_query` class to return `nil` if record is not found
+- Changed returned `json` to `{ details: <message_details> }` for malformed queries
+
 ## [0.2.0]
 ### Added
 - Pass `StellarFederation::Query` to `.on_query` callback class

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stellar_federation-rails (0.2.0)
+    stellar_federation-rails (0.2.1)
       dry-struct
       gem_config
       light-service

--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ StellarFederation.configure do |c|
 end
 ```
 
-`c.on_query` - is a class the you define: The `on_query` class should also return a `StellarFederation::QueryResponse`. If it doesn't, the Rails engine will throw an exception. The `on_query` class will be called with `.call`, that accepts a `StellarFederation::Query` object
+- `c.on_query` contains a class the you define
+- The `on_query` class should also return a `StellarFederation::QueryResponse`.
+- You can return nothing if you don't find a record
+- If you return something and it's not a `StellarFederation::QueryResponse`, the Rails engine will throw an exception.
+- The `on_query` class will be called with `.call`, that accepts a `StellarFederation::Query` object:
   - `address_name` - ex: `tunder_adebayo*your_org.com`
   - `address_id` - ex: `tunder_adebayo`
   - `address_domain` - ex: `your_org.com`

--- a/app/controllers/stellar_federation/api/v1/queries_controller.rb
+++ b/app/controllers/stellar_federation/api/v1/queries_controller.rb
@@ -10,12 +10,13 @@ module StellarFederation
               if result.success?
                 @query_response = result.query_response
 
-                render json: @query_response.to_json, status: :ok
+                if @query_response.present?
+                  render json: @query_response.to_json, status: :ok
+                else
+                  render json: @query_response.to_json, status: :not_found
+                end
               else
-                json_status = {
-                  status: "Unprocessable Entity",
-                  message: result.message,
-                }
+                json_status = { details: result.message }
 
                 render json: json_status, status: :unprocessable_entity
               end

--- a/app/services/stellar_federation/queries/trigger_on_query_callback_class.rb
+++ b/app/services/stellar_federation/queries/trigger_on_query_callback_class.rb
@@ -9,8 +9,10 @@ module StellarFederation
         begin
           c.query_response = callback_class.(c.query)
 
-          if !c.query_response.is_a? StellarFederation::QueryResponse
-            raise_return_error
+          if c.query_response.present?
+            if !c.query_response.is_a? StellarFederation::QueryResponse
+              raise_return_error
+            end
           end
         rescue NameError => e
           raise NameError, "StellarFederation.on_query isn't configured"

--- a/lib/stellar_federation/version.rb
+++ b/lib/stellar_federation/version.rb
@@ -1,3 +1,3 @@
 module StellarFederation
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/dummy/app/services/non_existent_stellar_federation_query.rb
+++ b/spec/dummy/app/services/non_existent_stellar_federation_query.rb
@@ -1,0 +1,7 @@
+class NonExistentStellarFederationQuery
+
+  def self.call(query)
+  end
+
+end
+

--- a/spec/requests/api/v1/queries_spec.rb
+++ b/spec/requests/api/v1/queries_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe "/api/v1/queries", type: :request do
       expect(response.status).to eq 422
 
       json = JSON.parse(response.body)
-      expect(json["message"]).to eq "Invalid Parameters"
-      expect(json["status"]).to eq "Unprocessable Entity"
+      expect(json["details"]).to eq "Invalid Parameters"
     end
   end
 
@@ -45,6 +44,29 @@ RSpec.describe "/api/v1/queries", type: :request do
       expect(json["account_id"]).to eq "FOOBAR"
       expect(json["memo_type"]).to eq "text"
       expect(json["memo"]).to eq 1
+    end
+  end
+
+  context "non-existent address" do
+    let(:valid_params) { { q: "foo*bar.com", type: "name" } }
+
+    before do
+      StellarFederation.configure do |c|
+        c.on_query = "NonExistentStellarFederationQuery"
+      end
+    end
+
+    after do
+      StellarFederation.configure do |c|
+        c.on_query = "ProcessStellarFederationQuery"
+      end
+    end
+
+    it "returns 404 and response object" do
+      get(uri, { params: valid_params })
+
+      expect(response.success?).to eq false
+      expect(response.status).to eq 404
     end
   end
 end


### PR DESCRIPTION
This pull request introduces the following:

- Add returned status to `404` if record is not found
- Allow `on_query` class to return `nil` if record is not found
- Changed returned `json` to `{ details: <message_details> }` for malformed queries
